### PR TITLE
Fix gradle/guides#204

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,36 @@ gradleRunner {
 
     step 'docOutput', cleanBuildOutput.curry('docs')
 
+    step 'filesAltered', { info ->
+        copy {
+            from workingDir
+            into info.reportDir
+
+            include 'build.gradle'
+
+            filesMatching (['build.gradle']) {
+                filter { line ->
+                    if (line =~ /^(\/\*)|(\s*\*)|(\/\/)/) {
+                        null
+                    } else {
+                        line
+                    }
+                }
+            }
+
+            filesMatching (['build.gradle']) {
+                filter { line ->
+                    if (line=~/\s*compile.+groovy-all/) {
+                        line.replace("compile", "compileOnly") +
+                        "\n" + line.replace("compile", "testCompile")
+                    } else {
+                        line
+                    }
+                }
+            }
+        }
+    }
+
     step 'files', { info ->
         copy {
             from workingDir

--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -65,7 +65,7 @@ include::{gradle-outdir}/files/build.gradle[]
 <3> Spock Framework testing library
 <4> JUnit testing library
 
-The build file adds the `groovy` plugin. This is an extension of the `java` plugins and adds additional tasks for compiling Groovy source code. It also allows for joint compilation of Groovy and Java files if found in the appropriate `groovy` source folders.
+The build file adds the `groovy` plugin. This is an extension of the `java` plugin and adds additional tasks for compiling Groovy source code. It also allows for joint compilation of Groovy and Java files if found in the appropriate `groovy` source folders.
 
 The file `src/main/groovy/Library.groovy` is shown here:
 

--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -67,6 +67,16 @@ include::{gradle-outdir}/files/build.gradle[]
 
 The build file adds the `groovy` plugin. This is an extension of the `java` plugin and adds additional tasks for compiling Groovy source code. It also allows for joint compilation of Groovy and Java files if found in the appropriate `groovy` source folders.
 
+[NOTE]
+====
+It is assumed that the consumer of the library will transitively want the Groovy jars on the classpath. For libraries that will be consumed in contexts where Groovy will already be on the classpath, you can consider altering your dependency scopes as follows:
+[source,groovy]
+----
+include::{gradle-outdir}/filesAltered/build.gradle[]
+----
+Alternatively, you may wish to document to your library users that they may need to exclude transitive dependencies or specifically exclude the Groovy jar to avoid having two (potentially conflicting) versions of Groovy on the classpath.
+====
+
 The file `src/main/groovy/Library.groovy` is shown here:
 
 .Generated src/main/groovy/Library.groovy


### PR DESCRIPTION
This PR is a suggested fix for Fix gradle/guides#204

I added new step into the build: `filesAltered` - to collect and alter files deviating from the automatically generated.

First such file is "build.gradle" which is altered in terms of scopes of module `groovy-all`.
This file is included into Asciidoc as an "info" block to describe the peculiarities reg. `groovy-all` module transitivity.

For your kind review.

Thanks you.